### PR TITLE
fix: replace global hostlisteners for select-box, suggestion-box and data-table-context menu

### DIFF
--- a/src/app/forms/select-box/terra-select-box.component.html
+++ b/src/app/forms/select-box/terra-select-box.component.html
@@ -7,7 +7,7 @@
                   'disabled': inputIsDisabled,
                   'open': _toggleOpen
                 }"
-     (click)="_toggleOpen =! _toggleOpen"
+     (click)="onClick($event)"
      container="body">
     
     <label *ngIf="_hasLabel" htmlFor="{{inputName}}">{{inputName}}

--- a/src/app/forms/select-box/terra-select-box.component.ts
+++ b/src/app/forms/select-box/terra-select-box.component.ts
@@ -22,10 +22,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
                        useExisting: forwardRef(() => TerraSelectBoxComponent),
                        multi:       true
                    }
-               ],
-               host:      {
-                   '(document:click)': 'clickedOutside($event)',
-               }
+               ]
            })
 export class TerraSelectBoxComponent implements OnInit, OnChanges
 {
@@ -37,6 +34,8 @@ export class TerraSelectBoxComponent implements OnInit, OnChanges
     @Input() inputListBoxValues:Array<TerraSelectBoxValueInterface>;
     @Output() outputValueChanged = new EventEmitter<TerraSelectBoxValueInterface>();
     @Output() inputSelectedValueChange = new EventEmitter<TerraSelectBoxValueInterface>();
+
+    private clickListener: (event: Event) => void;
 
     /**
      * @deprecated
@@ -78,6 +77,11 @@ export class TerraSelectBoxComponent implements OnInit, OnChanges
      */
     constructor(private elementRef:ElementRef)
     {
+        this.clickListener = (event) =>
+        {
+            this.clickedOutside(event);
+        };
+
         this._isInit = false;
         this.inputTooltipPlacement = 'top';
         this._selectedValue =
@@ -160,16 +164,41 @@ export class TerraSelectBoxComponent implements OnInit, OnChanges
         }
     }
 
+    private set toggleOpen(value)
+    {
+        if (this._toggleOpen !== value && value == true)
+        {
+            document.addEventListener('click', this.clickListener);
+        }
+        else if (this._toggleOpen !== value && value == false)
+        {
+            document.removeEventListener('click', this.clickListener);
+        }
+
+        this._toggleOpen = value;
+    }
+
+    private get toggleOpen():boolean
+    {
+        return this._toggleOpen;
+    }
+
     /**
      *
      * @param event
      */
-    private clickedOutside(event):void
+    private clickedOutside(event:Event):void
     {
         if(!this.elementRef.nativeElement.contains(event.target))
         {
-            this._toggleOpen = false;
+            this.toggleOpen = false;
         }
+    }
+
+    private onClick(evt:Event):void
+    {
+        evt.stopPropagation(); // prevents the click listener on the document to be fired right after
+        this.toggleOpen = !this.toggleOpen;
     }
 
     /**

--- a/src/app/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -25,9 +25,6 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
                        multi:       true
                    }
                ],
-               host:            {
-                   '(document:click)': 'clickedOutside($event)',
-               },
                changeDetection: ChangeDetectionStrategy.OnPush
            })
 
@@ -80,6 +77,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
     private _regex:string;
     private _isInit:boolean;
     private _value:number | string;
+    private clickListener:(event:Event) => void;
 
     /**
      *
@@ -104,6 +102,11 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
         {
             this.inputListBoxValues = [];
         }
+
+        this.clickListener = (event) =>
+        {
+            this.clickedOutside(event);
+        };
     }
 
     ngOnInit()
@@ -206,6 +209,26 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
         }
     }
 
+    public set toggleOpen(value:boolean)
+    {
+        if(this._toggleOpen !== value && value == true)
+        {
+            document.addEventListener('click', this.clickListener);
+        }
+        else if(this._toggleOpen !== value && value == false)
+        {
+            document.removeEventListener('click', this.clickListener);
+        }
+
+        this._toggleOpen = value;
+    }
+
+    public get toggleOpen():boolean
+    {
+        return this._toggleOpen;
+    }
+
+
     /**
      *
      * @param event
@@ -214,8 +237,9 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
     {
         if(!this.elementRef.nativeElement.contains(event.target))
         {
-            this._toggleOpen = false;
+            this.toggleOpen = false;
         }
+
     }
 
     /**
@@ -228,7 +252,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
         this.onTouchedCallback();
         this.onChangeCallback(value.value);
         this.outputValueChanged.emit(value);
-        this._toggleOpen = false;
+        this.toggleOpen = false;
     }
 
     /**
@@ -291,7 +315,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
      */
     public onFocus()
     {
-        this._toggleOpen = true;
+        this.toggleOpen = true;
     }
 
     /**
@@ -300,7 +324,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
      */
     public onBlur()
     {
-        this._toggleOpen = false;
+        this.toggleOpen = false;
     }
 
     /**
@@ -343,7 +367,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
             this.value = null;
             this.onTouchedCallback();
             this.onChangeCallback(null);
-            this._toggleOpen = false;
+            this.toggleOpen = false;
         }
     }
 

--- a/src/app/table/data-table/context-menu/terra-data-table-context-menu.component.ts
+++ b/src/app/table/data-table/context-menu/terra-data-table-context-menu.component.ts
@@ -9,13 +9,13 @@ import { TerraBaseData } from '../../../data/terra-base.data';
 @Component({
                selector: 'context-menu-holder',
                styles:   [require('./terra-data-table-context-menu.component.scss')],
-               template: require('./terra-data-table-context-menu.component.html'),
-               host:     {'(document:click)': 'clickedOutside()'}
+               template: require('./terra-data-table-context-menu.component.html')
            })
 export class TerraDataTableContextMenuComponent<D extends TerraBaseData>
 {
     private _contextMenuLinkList:Array<TerraDataTableContextMenuEntryInterface<D>> = [];
     private _isShown = false;
+    private clickListener: (event:Event) => void;
 
     private _mouseLocation:{ left:number, top:number } = {
         left: 0,
@@ -26,6 +26,12 @@ export class TerraDataTableContextMenuComponent<D extends TerraBaseData>
     {
         _contextMenuService.show.subscribe(
             e => this.showMenu(e.event, e.obj));
+
+        this.clickListener = (event) =>
+        {
+            this.clickedOutside();
+            event.stopPropagation();
+        }
     }
 
     get locationCss()
@@ -39,7 +45,8 @@ export class TerraDataTableContextMenuComponent<D extends TerraBaseData>
 
     clickedOutside()
     {
-        this._isShown = false
+        this._isShown = false;
+        document.removeEventListener('click', this.clickListener);
     }
 
     showMenu(event,
@@ -50,6 +57,9 @@ export class TerraDataTableContextMenuComponent<D extends TerraBaseData>
         this._mouseLocation = {
             left: event.clientX,
             top:  event.clientY
-        }
+        };
+
+        event.stopPropagation();
+        document.addEventListener('click', this.clickListener);
     }
 }


### PR DESCRIPTION
* Do not register HostListener to the document for every select box component.
* Instead register EventListener only when the dropdown is opened.
* Remove added EventListener afterwards to prevent ChangeDetection to be fired
* also replace host listeners in "terra-suggestion-box" and "terra-data-table-context-menu" with dynamically attached EventListeners

@plentymarkets/team-terra 