### PR TITLE
Allow target parameter when building terra-components

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var git = require('gulp-git');
 var gitignore = require('gulp-gitignore');
 var shell = require('gulp-shell');
 var argv = require('yargs').argv;
+var path = require('path');
 
 var version, level, sequence, subversion;
 
@@ -25,6 +26,7 @@ var version, level, sequence, subversion;
  * @param level      - Possible values are major (1.x.x to 2.x.x), minor (x.1.x to x.2.x) or patch (x.x.1 to x.x.2).
  *                     If not set patch is default. See VERSIONING.md for further information.
  * @param subversion - Sets a subversion (appends '-param_value', e.g. x.x.x-newFeature, to version in package.json). Use only, if really necessary!!
+ * @param target     - Sets the target directory to copy build files to. Will copy files to 'node_modules/@plentymarkets/terra-components' in target directory
  *
  **/
 gulp.task('build', function(callback)
@@ -65,7 +67,7 @@ gulp.task('build-local', function (callback)
         'copy-fonts',
         'copy-images',
         'copy-lang',
-        'copy-to-terra',
+        'copy-to-target',
         callback
     );
 });
@@ -205,11 +207,14 @@ gulp.task('copy-lang', function ()
                .pipe(gulp.dest(config.langOutputPath));
 });
 
-//copy files from dist to terra
-gulp.task('copy-to-terra', function ()
+//copy files from dist to defined directory
+gulp.task('copy-to-target', function ()
 {
+    var target = argv.target || '/workspace/terra';
     return gulp.src('dist/**/*.*')
-               .pipe(gulp.dest('../terra/node_modules/@plentymarkets/terra-components/'));
+        .pipe(
+            gulp.dest( path.join( target, '/node_modules/@plentymarkets/terra-components/' ) )
+        );
 });
 
 //publish to npm


### PR DESCRIPTION
@nappynapster @MFrank84 

Erlaubt die Angabe eines Ziel-Projekts, um die Terra-Components zu kopieren:
```
npm run build -- --target /PATH/TO/PROJECT
```
=> Kopiert die build-files nach `/PATH/TO/PROJECT/node_modules/@plentymarkets/terra-components`
