### PR TITLE
Feature/collapsable portlet

### DIFF
--- a/src/app/portlet/terra-portlet.component.html
+++ b/src/app/portlet/terra-portlet.component.html
@@ -1,8 +1,9 @@
-<div class="portlet">
-    <div class="portlet_head">
-        {{inputPortletHeader}}
+<div class="portlet" [class.collapsable]="isCollapsable">
+    <div class="portlet_head" (click)="toggleCollapse()">
+        <span>{{inputPortletHeader}}</span>
+        <span class="icon-collapse_down" [class.rotated]="collapsed" *ngIf="isCollapsable"></span>
     </div>
-    <div class="portlet_body">
+    <div class="portlet_body" [@collapsedState]="collapsedState">
         <ng-content></ng-content>
     </div>
 </div>

--- a/src/app/portlet/terra-portlet.component.html
+++ b/src/app/portlet/terra-portlet.component.html
@@ -1,7 +1,7 @@
-<div class="portlet" [class.collapsable]="isCollapsable">
+<div class="portlet" [class.collapsable]="inputIsCollapsable">
     <div class="portlet_head" (click)="toggleCollapse()">
         <span>{{inputPortletHeader}}</span>
-        <span class="icon-collapse_down" [class.rotated]="collapsed" *ngIf="isCollapsable"></span>
+        <span class="icon-collapse_down" [class.rotated]="inputCollapsed" *ngIf="inputIsCollapsable"></span>
     </div>
     <div class="portlet_body" [@collapsedState]="collapsedState">
         <ng-content></ng-content>

--- a/src/app/portlet/terra-portlet.component.scss
+++ b/src/app/portlet/terra-portlet.component.scss
@@ -29,6 +29,8 @@
     {
         padding: 12px;
         font-size: $font-size-base;
+        overflow: hidden;
+
         table.table
         {
             thead
@@ -84,6 +86,12 @@
             }
         }
     }
+
+    &.collapsable {
+        .portlet_head {
+            cursor: pointer;
+        }
+    }
 }
 
 .config-table
@@ -111,6 +119,12 @@
     [class^="icon-"]
     {
         float: right;
+        padding: 3px 3px;
+        transition: all 100ms ease;
+
+        &.rotated {
+            transform: rotate(180deg);
+        }
     }
 }
 

--- a/src/app/portlet/terra-portlet.component.ts
+++ b/src/app/portlet/terra-portlet.component.ts
@@ -1,18 +1,79 @@
 import {
-    Component,
-    Input
+    Component, EventEmitter,
+    Input, OnChanges, Output, SimpleChanges
 } from '@angular/core';
+import { animate, state, style, transition, trigger } from "@angular/animations";
 
 @Component({
-               selector: 'terra-portlet',
-               styles:   [require('./terra-portlet.component.scss')],
-               template: require('./terra-portlet.component.html')
-           })
-export class TerraPortletComponent
+    selector: 'terra-portlet',
+    styles:   [require('./terra-portlet.component.scss')],
+    template: require('./terra-portlet.component.html'),
+    animations: [
+        trigger('collapsedState', [
+            state('collapsed', style({
+                height: 0,
+                'padding-top': 0,
+                'padding-bottom': 0
+            })),
+            state('expanded', style({
+                height: '*'
+            })),
+            transition('collapsed <=> expanded', [
+                animate(100)
+            ])
+        ])
+    ]
+})
+export class TerraPortletComponent implements OnChanges
 {
+
     @Input() inputPortletHeader:string;
+
+    @Input() isCollapsable: boolean = false;
+
+    @Input() collapsed: boolean = false;
+
+    @Output() collapsedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    private get collapsedState(): string
+    {
+        if ( !this.isCollapsable )
+        {
+            return 'expanded';
+        }
+
+        if ( this.collapsed )
+        {
+            return 'collapsed';
+        }
+
+        return 'expanded';
+    }
 
     constructor()
     {
+    }
+
+    public ngOnChanges( changes: SimpleChanges ): void
+    {
+        if( changes.hasOwnProperty( "isCollapsable") && !this.isCollapsable )
+        {
+            this.collapsed = false;
+            setTimeout( () => {
+                this.collapsedChange.emit( false );
+            });
+        }
+    }
+
+    public toggleCollapse(): void
+    {
+        this.collapsed = !this.collapsed;
+
+        if ( !this.isCollapsable )
+        {
+            this.collapsed = false;
+        }
+
+        this.collapsedChange.emit( this.collapsed );
     }
 }

--- a/src/app/portlet/terra-portlet.component.ts
+++ b/src/app/portlet/terra-portlet.component.ts
@@ -20,7 +20,7 @@ import {
     template: require('./terra-portlet.component.html'),
     animations: [
         trigger('collapsedState', [
-            state('collapsed', style({
+            state('inputCollapsed', style({
                 height: 0,
                 'padding-top': 0,
                 'padding-bottom': 0
@@ -28,7 +28,7 @@ import {
             state('expanded', style({
                 height: '*'
             })),
-            transition('collapsed <=> expanded', [
+            transition('inputCollapsed <=> expanded', [
                 animate(100)
             ])
         ])
@@ -39,22 +39,22 @@ export class TerraPortletComponent implements OnChanges
 
     @Input() inputPortletHeader:string;
 
-    @Input() isCollapsable: boolean = false;
+    @Input() inputIsCollapsable: boolean = false;
 
-    @Input() collapsed: boolean = false;
+    @Input() inputCollapsed: boolean = false;
 
-    @Output() collapsedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+    @Output() inputCollapsedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     private get collapsedState(): string
     {
-        if ( !this.isCollapsable )
+        if ( !this.inputIsCollapsable )
         {
             return 'expanded';
         }
 
-        if ( this.collapsed )
+        if ( this.inputCollapsed )
         {
-            return 'collapsed';
+            return 'inputCollapsed';
         }
 
         return 'expanded';
@@ -66,24 +66,24 @@ export class TerraPortletComponent implements OnChanges
 
     public ngOnChanges( changes: SimpleChanges ): void
     {
-        if( changes.hasOwnProperty( "isCollapsable") && !this.isCollapsable )
+        if( changes.hasOwnProperty( "inputIsCollapsable") && !this.inputIsCollapsable )
         {
-            this.collapsed = false;
+            this.inputCollapsed = false;
             setTimeout( () => {
-                this.collapsedChange.emit( false );
+                this.inputCollapsedChange.emit( false );
             });
         }
     }
 
     public toggleCollapse(): void
     {
-        this.collapsed = !this.collapsed;
+        this.inputCollapsed = !this.inputCollapsed;
 
-        if ( !this.isCollapsable )
+        if ( !this.inputIsCollapsable )
         {
-            this.collapsed = false;
+            this.inputCollapsed = false;
         }
 
-        this.collapsedChange.emit( this.collapsed );
+        this.inputCollapsedChange.emit( this.inputCollapsed );
     }
 }

--- a/src/app/portlet/terra-portlet.component.ts
+++ b/src/app/portlet/terra-portlet.component.ts
@@ -1,8 +1,18 @@
 import {
-    Component, EventEmitter,
-    Input, OnChanges, Output, SimpleChanges
+    Component,
+    EventEmitter,
+    Input,
+    OnChanges,
+    Output,
+    SimpleChanges
 } from '@angular/core';
-import { animate, state, style, transition, trigger } from "@angular/animations";
+import {
+    animate,
+    state,
+    style,
+    transition,
+    trigger
+} from "@angular/animations";
 
 @Component({
     selector: 'terra-portlet',

--- a/src/app/terra-components.module.ts
+++ b/src/app/terra-components.module.ts
@@ -65,6 +65,7 @@ import { TerraMultiSplitViewComponent } from './split-view/multi/terra-multi-spl
 import { TerraSplitViewComponent } from './split-view/terra-split-view.component';
 import { CommonModule } from '@angular/common';
 import { TerraDynamicComponentLoaderComponent } from './dynamic-component-loader/terra-dynamic-component-loader.component';
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 export { TerraAlertPanelComponent } from './alert/terra-alert-panel.component';
 export { TerraAlertComponent } from './alert/terra-alert.component';
 export { TerraButtonInterface } from './button/data/terra-button.interface';
@@ -256,6 +257,7 @@ export { TerraSyntaxEditorData } from './editor/syntax/data/terra-syntax-editor.
                   TerraSyntaxEditorComponent
               ],
               imports:         [
+                  BrowserAnimationsModule,
                   CommonModule,
                   FormsModule,
                   ReactiveFormsModule,


### PR DESCRIPTION
@plentymarkets/team-terra 

Neue Input-Properties ermöglichen es, Portlets "einklappbar" zu gestalten:
```
<terra-portlet
        [inputPortletHeader]="'MyHeader'"
        [isCollapsable]="isCollapsable"
        [(collapsed)]="collapsed">
    <p>Content</p>
</terra-portlet>

<!-- Toggle collapse from parent component -->
<p>Collapsed: {{ collapsed }}</p>
<button (click)="isCollapsable = !isCollapsable">Toggle isCollapsable</button>
<button (click)="collapsed = !collapsed">Toggle portlet</button>
```