### PR TITLE
feature: (multi-split-view) refocus selected view on tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 # Unreleased 
 
 ### Feature
-* **terra-multi-split-view** added function to close selected views via dropdown
+* **terra-multi-split-view** 
+	- added function to close selected views via dropdown
+	- added new inputs _inputRouter_ and _inputComponentRoute_ to catch routing events and to access the routing config
 * **terra-base-toolbar** Added input 'inputIsSticky' to set the toolbar sticky at top of containing container
 	
 ### Bug Fixes

--- a/src/app/split-view/multi/terra-multi-split-view.component.ts
+++ b/src/app/split-view/multi/terra-multi-split-view.component.ts
@@ -16,6 +16,7 @@ import {
     Routes
 } from '@angular/router';
 import * as AngularRouter from '@angular/router'; // Required to use both Angular Router Events and ES6 Events
+
 @Component({
                selector: 'terra-multi-split-view',
                template: require('./terra-multi-split-view.component.html'),

--- a/src/app/split-view/multi/terra-multi-split-view.component.ts
+++ b/src/app/split-view/multi/terra-multi-split-view.component.ts
@@ -26,8 +26,8 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
 {
     @Input() inputConfig:TerraMultiSplitViewConfig;
     @Input() inputShowBreadcrumbs:boolean;
-    @Input() router:Router;     // to catch router events
-    @Input() componentRoute:string; // to catch the routing event, when selecting the tab where the split view is instantiated
+    @Input() inputRouter:Router;     // to catch inputRouter events
+    @Input() inputComponentRoute:string; // to catch the routing event, when selecting the tab where the split view is instantiated
 
     @HostListener('window:resize')
     onWindowResize()
@@ -72,15 +72,15 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
     ngOnInit()
     {
         // catch routing events, but only those that select the tab where the split view is instantiated
-        if (!isNullOrUndefined(this.router)
-            && !isNullOrUndefined(this.componentRoute))
+        if (!isNullOrUndefined(this.inputRouter)
+            && !isNullOrUndefined(this.inputComponentRoute))
         {
             // check if the given route exists in the route config
-            if(this.routeExists(this.componentRoute))
+            if(this.routeExists(this.inputComponentRoute))
             {
                 // register event listener
-                this.router.events
-                    .filter((event:AngularRouter.Event) => event instanceof NavigationStart && event.url === this.componentRoute)
+                this.inputRouter.events
+                    .filter((event:AngularRouter.Event) => event instanceof NavigationStart && event.url === this.inputComponentRoute)
                     .subscribe((path:NavigationStart) => {
                         this.updateViewport(this.inputConfig.currentSelectedView, true);
                     });
@@ -498,7 +498,7 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
         let routeLevel:number = 1;
 
         // get the routing config
-        let routes:Routes = this.router.config;
+        let routes:Routes = this.inputRouter.config;
 
         // scan the routing config
         while (routeLevel < path.length)

--- a/src/app/split-view/multi/terra-multi-split-view.component.ts
+++ b/src/app/split-view/multi/terra-multi-split-view.component.ts
@@ -12,7 +12,8 @@ import { TerraMultiSplitViewDetail } from './data/terra-multi-split-view-detail'
 import { TerraMultiSplitViewInterface } from './data/terra-multi-split-view.interface';
 import {
     NavigationStart,
-    Router
+    Router,
+    Routes
 } from '@angular/router';
 import * as AngularRouter from '@angular/router';
 @Component({
@@ -73,8 +74,10 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
         if (!isNullOrUndefined(this.router)
             && !isNullOrUndefined(this.componentRoute))
         {
-            if(this.router.config.find((route) => route === this.componentRoute))
+            // check if the given route exists in the route config
+            if(this.routeExists(this.componentRoute))
             {
+                // register event listener
                 this.router.events
                     .filter((event:AngularRouter.Event) => event instanceof NavigationStart && event.url === this.componentRoute)
                     .subscribe((path:NavigationStart) => {
@@ -485,16 +488,40 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
         this.inputConfig.removeView(view);
     }
 
-    private checkIfRouteExists(route:string):void
+    private routeExists(route:string):boolean
     {
+        // get the partials of the route
         let path:Array<string> = route.split('/');
 
-        path.forEach(
-            (section) =>
-            {
-                if(this.router.config.find((route) => route.path === section));
-            }
-        )
+        // start at element 1 not 0, since the route starts with a separator
+        let routeLevel:number = 1;
 
+        // get the routing config
+        let routes:Routes = this.router.config;
+
+        // scan the routing config
+        while (routeLevel < path.length)
+        {
+            if(isNullOrUndefined(routes))
+            {
+                return false;
+            }
+
+            // search the array for the route partial
+            let foundRoute = routes.find((route) => route.path === path[routeLevel]);
+            if(foundRoute) // the route partial is defined?
+            {
+                // into deep
+                routeLevel++;
+                routes = foundRoute.children;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        // if the while loop ends, the route exists
+        return true;
     }
 }

--- a/src/app/split-view/multi/terra-multi-split-view.component.ts
+++ b/src/app/split-view/multi/terra-multi-split-view.component.ts
@@ -10,7 +10,11 @@ import { isNullOrUndefined } from 'util';
 import { TerraMultiSplitViewConfig } from './data/terra-multi-split-view.config';
 import { TerraMultiSplitViewDetail } from './data/terra-multi-split-view-detail';
 import { TerraMultiSplitViewInterface } from './data/terra-multi-split-view.interface';
-
+import {
+    NavigationStart,
+    Router
+} from '@angular/router';
+import * as AngularRouter from '@angular/router';
 @Component({
                selector: 'terra-multi-split-view',
                template: require('./terra-multi-split-view.component.html'),
@@ -20,6 +24,8 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
 {
     @Input() inputConfig:TerraMultiSplitViewConfig;
     @Input() inputShowBreadcrumbs:boolean;
+    @Input() router:Router;     // to catch router events
+    @Input() componentRoute:string; // to catch the routing event, when selecting the tab where the split view is instantiated
 
     @HostListener('window:resize')
     onWindowResize()
@@ -63,6 +69,20 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
 
     ngOnInit()
     {
+        // catch routing events, but only those that select the tab where the split view is instantiated
+        if (!isNullOrUndefined(this.router)
+            && !isNullOrUndefined(this.componentRoute))
+        {
+            if(this.router.config.find((route) => route === this.componentRoute))
+            {
+                this.router.events
+                    .filter((event:AngularRouter.Event) => event instanceof NavigationStart && event.url === this.componentRoute)
+                    .subscribe((path:NavigationStart) => {
+                        this.updateViewport(this.inputConfig.currentSelectedView, true);
+                    });
+            }
+        }
+
         this.inputConfig.addViewEventEmitter.subscribe(
             (value:TerraMultiSplitViewInterface) =>
             {
@@ -463,5 +483,18 @@ export class TerraMultiSplitViewComponent implements OnDestroy, OnInit
 
         // remove the selected view
         this.inputConfig.removeView(view);
+    }
+
+    private checkIfRouteExists(route:string):void
+    {
+        let path:Array<string> = route.split('/');
+
+        path.forEach(
+            (section) =>
+            {
+                if(this.router.config.find((route) => route.path === section));
+            }
+        )
+
     }
 }

--- a/src/app/split-view/multi/terra-multi-split-view.component.ts
+++ b/src/app/split-view/multi/terra-multi-split-view.component.ts
@@ -15,7 +15,7 @@ import {
     Router,
     Routes
 } from '@angular/router';
-import * as AngularRouter from '@angular/router';
+import * as AngularRouter from '@angular/router'; // Required to use both Angular Router Events and ES6 Events
 @Component({
                selector: 'terra-multi-split-view',
                template: require('./terra-multi-split-view.component.html'),


### PR DESCRIPTION
..the generic solution

**new inputs**

- `inputRouter`: pass the angular router to access the route config and its events
- `inputComponentRoute`: state the route of the component, that instantiates the split-view

@plentymarkets/team-terra 