### PR TITLE
FIX show drop down of select box which is used in portlet

### DIFF
--- a/src/app/portlet/terra-portlet.component.scss
+++ b/src/app/portlet/terra-portlet.component.scss
@@ -91,6 +91,10 @@
         {
             cursor: pointer;
         }
+        .portlet_body
+        {
+            overflow: hidden;
+        }
     }
 }
 

--- a/src/app/portlet/terra-portlet.component.scss
+++ b/src/app/portlet/terra-portlet.component.scss
@@ -29,8 +29,6 @@
     {
         padding: 12px;
         font-size: $font-size-base;
-        overflow: hidden;
-        
         table.table
         {
             thead


### PR DESCRIPTION
@felixdausch: du hattest die Zeile eingebaut. leider wird das Drop-Down der Select Box in einem Portlet nicht mehr angezeigt. siehst du eine andere Lösung für den Anwendungsfalls, für den du das overflow eingebaut hast?

@vwiebe, @zakpur 
