### PR TITLE
feature (multi-split-view): restrict public data model access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#Unreleased
+### Bug Fixes
+* **terra-multi-split-view** disable public access to the data model, since it shouldn't be edited manually
+
 <a name="1.4.2"></a>
 # 1.4.2 (20.09.2017)
 ### Feature

--- a/src/app/split-view/multi/data/terra-multi-split-view.config.ts
+++ b/src/app/split-view/multi/data/terra-multi-split-view.config.ts
@@ -28,7 +28,7 @@ export class TerraMultiSplitViewConfig
                     if(isNullOrUndefined(this.currentSelectedView))
                     {
                         this.currentSelectedView = view;
-                        this.views.push(view);
+                        this._views.push(view);
                     }
                     else
                     {
@@ -121,16 +121,6 @@ export class TerraMultiSplitViewConfig
     public get addViewEventEmitter():EventEmitter<TerraMultiSplitViewInterface>
     {
         return this._addViewEventEmitter;
-    }
-
-    public get views():Array<TerraMultiSplitViewInterface>
-    {
-        return this._views;
-    }
-
-    public set views(value:Array<TerraMultiSplitViewInterface>)
-    {
-        this._views = value;
     }
 
     public get currentSelectedView():TerraMultiSplitViewInterface


### PR DESCRIPTION
* disable public access to the data model, since it shouldn't be edited manually

@plentymarkets/team-terra 