### PR TITLE
FIX - overflow infobox

### DIFF
--- a/src/app/info-box/terra-info-box.component.scss
+++ b/src/app/info-box/terra-info-box.component.scss
@@ -30,11 +30,17 @@
     max-width: 77%;
 }
 
-:host /deep/ .info-box-text div
+:host /deep/ .info-box-text
 {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+    div{
+        text-overflow: ellipsis;
+        /* overflow: hidden; */
+        white-space: nowrap;
+    }
+    
+    i, span, p, h1, h2, h3, h4, h5, h6{
+        overflow: hidden;
+    }
 }
 
 .empty


### PR DESCRIPTION
@plentymarkets/team-terra 

Statt form elements direkt in eine table zu packen, sollen wir auf die info-box ausweichen...
Geht leider bei select-box nicht da overflow hidden auf alle divs gesetzt war. Dadurch werden absolut positionierte Elemente nicht mehr angezeigt, unter anderem das dropdown der select-box.

Ich habe das overflow hidden nun aus dem div selector entfernt und statt dessen einer liste von text elementen hinzugefügt.