### PR TITLE
FIX - select default value

### DIFF
--- a/src/app/forms/select-box/terra-select-box.component.ts
+++ b/src/app/forms/select-box/terra-select-box.component.ts
@@ -108,7 +108,7 @@ export class TerraSelectBoxComponent implements OnInit, OnChanges
         if(this._isInit == true
            && changes["inputListBoxValues"]
            && changes["inputListBoxValues"].currentValue.length > 0
-           && this.inputListBoxValues.find((x) => this._selectedValue === x))
+           && !this.inputListBoxValues.find((x) => this._selectedValue === x))
         {
             this.select(this.inputListBoxValues[0]);
         }

--- a/src/app/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -97,7 +97,7 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
     {
         if(changes["inputListBoxValues"]
            && changes["inputListBoxValues"].currentValue.length > 0
-           && this.inputListBoxValues.find((x) => this._selectedValue === x))
+           && !this.inputListBoxValues.find((x) => this._selectedValue === x))
         {
             setTimeout(() =>
             {


### PR DESCRIPTION
@plentymarkets/team-terra 
Siehe commit https://github.com/plentymarkets/terra-components/commit/856eee97d5683795a797039ee1b8ee7075826b9b#diff-bccd4520ce42140ff02219085af8e7ee

```
-           && this.inputListBoxValues.indexOf(this._selectedValue) == -1)
+           && this.inputListBoxValues.find((x) => this._selectedValue === x))
```

Vorher `== -1` also wenn **nicht** gefunden. Nach dem change dann **true** nur **wenn gefunden** 