### PR TITLE
ADD option to disable single rows in simple-table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Use `arrow up` / `arrow down` to navigate throught table rows.
 Use `space` or `enter` to toggle checkbox of selected row 
 or `ctrl`/`cmd` + `space`/`enter` to toggle checkbox in table header.
 Toggling checkboxes required `[inputHasCheckbox]="true"`
+* **terra-simple-table** Add option to disable single rows to `TerraSimpleTableRowInterface`. Disabled rows may not be highlighted (using `inputUseHighlighting`) or selected when having checkboxes activated (`inputHasCheckbox`)
 * **terra-data-table-no-result-notice-component** new component, that can be used to display a notice whenever no results are available
+
 
 ### Bug Fixes
 * **terra-multi-split-view** 

--- a/src/app/table/data-table/terra-data-table.component.scss
+++ b/src/app/table/data-table/terra-data-table.component.scss
@@ -76,6 +76,11 @@ table.table
             }
         }
     }
+    tbody.highlighting tr.disabled
+    {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
 }
 
 .no-margin

--- a/src/app/table/simple/row/terra-simple-table-row.interface.ts
+++ b/src/app/table/simple/row/terra-simple-table-row.interface.ts
@@ -10,4 +10,5 @@ export interface TerraSimpleTableRowInterface<D>
     value?:D;
     textColorCss?:string;
     backgroundColor?:string;
+    disabled?:boolean;
 }

--- a/src/app/table/simple/terra-simple-table.component.html
+++ b/src/app/table/simple/terra-simple-table.component.html
@@ -20,12 +20,17 @@
             </ng-template>
         </tr>
         </thead>
-        <tbody>
+        <tbody [class.highlighting]="inputUseHighlighting">
         <ng-template ngFor let-row [ngForOf]="inputRowList">
-            <tr [ngClass]="row.textColorCss" [ngStyle]="{'background-color': row.backgroundColor}" [class.isActive]="row === inputHighlightedRow" (click)="onRowClick(row)">
+            <tr [ngClass]="row.textColorCss"
+                [ngStyle]="{'background-color': row.backgroundColor}"
+                [class.isActive]="row === inputHighlightedRow"
+                [class.disabled]="row.disabled"
+                (click)="onRowClick(row)">
                 <td *ngIf="inputHasCheckboxes">
                     <terra-checkbox #rowCheckbox
                                     [value]="row.selected"
+                                    [inputIsDisabled]="row.disabled"
                                     (change)="onRowCheckboxChange(rowCheckbox.value, row)">
                     </terra-checkbox>
                 </td>
@@ -46,7 +51,7 @@
                                               [inputIsPrimary]="button.isPrimary"
                                               [inputIsSecondary]="button.isSecondary"
                                               [inputIsTertiary]="button.isTertiary"
-                                              [inputIsDisabled]="button.isDisabled"
+                                              [inputIsDisabled]="button.isDisabled || row.disabled "
                                               [inputTooltipPlacement]="checkTooltipPlacement(button.tooltipPlacement)"
                                               [inputCaption]="button.caption"
                                               [inputIsSmall]="true"

--- a/src/app/table/simple/terra-simple-table.component.ts
+++ b/src/app/table/simple/terra-simple-table.component.ts
@@ -102,14 +102,13 @@ export class TerraSimpleTableComponent<D>
 
         this.outputHeaderCheckBoxChanged.emit(isChecked);
 
-        this.inputRowList.forEach(
-            (row) =>
+        this.inputRowList.forEach((row) =>
+        {
+            if(!row.disabled)
             {
-                if ( !row.disabled )
-                {
-                    this.changeRowState(isChecked, row);
-                }
-            });
+                this.changeRowState(isChecked, row);
+            }
+        });
     }
 
     private onRowCheckboxChange(isChecked:boolean, row:TerraSimpleTableRowInterface<D>):void
@@ -170,12 +169,12 @@ export class TerraSimpleTableComponent<D>
     {
         if(this.inputHighlightedRow)
         {
-            let i: number = nextSibling ? 1 : -1;
+            let i:number = nextSibling ? 1 : -1;
             let highlightIndex:number = this.inputRowList.indexOf(this.inputHighlightedRow) + i;
 
-            while( highlightIndex >= 0 && highlightIndex < this.inputRowList.length )
+            while(highlightIndex >= 0 && highlightIndex < this.inputRowList.length)
             {
-                if ( !this.inputRowList[highlightIndex].disabled )
+                if(!this.inputRowList[highlightIndex].disabled)
                 {
                     this.inputHighlightedRow = this.inputRowList[highlightIndex];
                     this.outputHighlightedRowChange.emit(this.inputHighlightedRow);

--- a/src/app/table/simple/terra-simple-table.component.ts
+++ b/src/app/table/simple/terra-simple-table.component.ts
@@ -105,7 +105,10 @@ export class TerraSimpleTableComponent<D>
         this.inputRowList.forEach(
             (row) =>
             {
-                this.changeRowState(isChecked, row);
+                if ( !row.disabled )
+                {
+                    this.changeRowState(isChecked, row);
+                }
             });
     }
 
@@ -130,7 +133,7 @@ export class TerraSimpleTableComponent<D>
 
     private onRowClick(row:TerraSimpleTableRowInterface<D>):void
     {
-        if(this.inputUseHighlighting)
+        if(this.inputUseHighlighting && !row.disabled)
         {
             this.inputHighlightedRow = row;
             this.outputHighlightedRowChange.emit(this.inputHighlightedRow);
@@ -167,7 +170,21 @@ export class TerraSimpleTableComponent<D>
     {
         if(this.inputHighlightedRow)
         {
-            let highlightIndex:number = this.inputRowList.indexOf(this.inputHighlightedRow);
+            let i: number = nextSibling ? 1 : -1;
+            let highlightIndex:number = this.inputRowList.indexOf(this.inputHighlightedRow) + i;
+
+            while( highlightIndex >= 0 && highlightIndex < this.inputRowList.length )
+            {
+                if ( !this.inputRowList[highlightIndex].disabled )
+                {
+                    this.inputHighlightedRow = this.inputRowList[highlightIndex];
+                    this.outputHighlightedRowChange.emit(this.inputHighlightedRow);
+                    break;
+                }
+                highlightIndex += i;
+            }
+
+            /*
             if(nextSibling && highlightIndex < this.inputRowList.length - 1)
             {
                 this.inputHighlightedRow = this.inputRowList[highlightIndex + 1];
@@ -178,6 +195,7 @@ export class TerraSimpleTableComponent<D>
                 this.inputHighlightedRow = this.inputRowList[highlightIndex - 1];
                 this.outputHighlightedRowChange.emit(this.inputHighlightedRow);
             }
+            */
         }
     }
 


### PR DESCRIPTION
@plentymarkets/team-terra 

Additionally set option `disabled` in `TerraSimpleTableRowInterface` to disable a single table row.
- When having `inputUseHighlighting` disabled rows may not be highlighted. Clicking a row will emit `outputRowClicked` but not `outputHighlightedRowChange`
- When having `inputEnableHotkeys` disabled rows will be skipped.
- When having `inputHasCheckbox`, checkboxes of disabled rows will be disabled too.
- When having `inputHasCheckbox` the header checkbox will not affect checkboxes of disabled rows.
- When having Buttons defined in `TerraSimpleTableRowInterface.cellList.buttonList` all buttons will be disabled.

see: https://github.com/plentymarkets/terra/pull/411