### PR TITLE
TerraDataTable bug fixes

### DIFF
--- a/src/app/table/data-table/terra-data-table.component.html
+++ b/src/app/table/data-table/terra-data-table.component.html
@@ -11,7 +11,7 @@
     <table class="table data-table">
         <thead>
         <tr>
-            <th *ngIf="inputHasCheckboxes" width="25px">
+            <th *ngIf="inputHasCheckboxes && _rowList.length" width="25px">
                 <terra-checkbox #viewChildHeaderCheckbox
                                 (change)="onHeaderCheckboxChange(viewChildHeaderCheckbox.value)"
                                 [value]="_isHeaderCheckboxChecked">

--- a/src/app/table/data-table/terra-data-table.component.ts
+++ b/src/app/table/data-table/terra-data-table.component.ts
@@ -69,6 +69,8 @@ export class TerraDataTableComponent<S extends TerraBaseService, D extends Terra
         this.inputHasCheckboxes = true;
         this.inputHasInitialLoading = false;
         this.inputHasPager = true;
+        
+        this.rowList = [];
     }
 
 


### PR DESCRIPTION
- fixed bug that occurred when table has not loaded yet but header checkbox is clicked. The event triggered the row iteration which at that point was an null object causing errors

- fixed display bug that occurred when inputHasCheckbox value was given but table has not loaded yet. The header checkbox was shown although table content was not loaded.