### PR TITLE
fix (data-table): remove underline text decoration for href elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Feature
 * **url-helper** new component that offers methods to edit urls
 * **terra-multi-split-view** inject router instead of passing it via the input `inputRouter`.
+* **terra-data-table** replace underline text decoration of phone and email links with blue color highlighting.
 
 <a name="2.1.47-zlk"></a>
 # 2.1.47-zlk (06.02.2018)

--- a/src/app/components/tables/data-table/terra-data-table.component.scss
+++ b/src/app/components/tables/data-table/terra-data-table.component.scss
@@ -62,10 +62,12 @@
                     }
                     a[href]
                     {
-                        text-decoration: underline;
+                        text-decoration: none;
+                        color: $blue;
                         &:hover
                         {
-                            color: $blue;
+                            text-decoration: underline;
+                            color: $blue-hover;
                         }
                     }
                 }


### PR DESCRIPTION
... use blue highlight color instead

@plentymarkets/team-terra 