### PR TITLE
feature (suggestion-box): get text input value and reset selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
     * Select a Value from the suggestions if the entered text matches its caption
     * `selectedValue` is reset if `inputListBoxValues` is updated and the previous selected element is not present anymore
     * `selectedValue = null` if entered text does not match any of the `inputListBoxValues`
-    * removed `resetComponentValue`-Method. Use `ngModel` instead to set the value to `null`
-    * `outputValueChanged` is now deprecated
+    * `resetComponentValue`-Method is now deprecated. Use `ngModel` instead to set the value to `null`
+    * `outputValueChanged` is now deprecated. Use `ngModelChange` instead.
     
 ### Bug Fixes
 * **terra-split-view** Fix for a null pointer. This component is deprecated, please use `TerraMultiSplitViewComponent` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+### Feature
+* **terra-suggestion-box** 
+	* New Output `textInputValueChange` that emits the current text input value
+    * Select a Value from the suggestions if the entered text matches its caption
+    * `selectedValue` is reset if `inputListBoxValues` is updated and the previous selected element is not present anymore
+    * `selectedValue = null` if entered text does not match any of the `inputListBoxValues`
+    * removed `resetComponentValue`-Method. Use `ngModel` instead to set the value to `null`
+    * `outputValueChanged` is now deprecated
+
 <a name="2.3.10"></a>
 # 2.3.10 (09.08.2018)
 

--- a/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.html
+++ b/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.html
@@ -4,13 +4,15 @@
             <div class="col-md-8">
                 <terra-suggestion-box
                     inputName="icons"
-                    [inputListBoxValues]="_iconList"
-                    [(ngModel)]="_iconClass">
+                    [inputListBoxValues]="iconList"
+                    [(ngModel)]="iconClass"
+                    (textInputValueChanged)="textInputValue = $event">
                 </terra-suggestion-box>
             </div>
-            <div  class="col-md-4 text-md-left h2">
-               <span [ngClass]="_iconClass"></span>
-               <span>{{_iconClass}}</span>
+            <div class="col-md-4 text-md-left h2">
+                <span [ngClass]="iconClass"></span>
+                <span>{{iconClass}}</span>
+                <span>{{textInputValue}}</span>
             </div>
         </div>
     </div>

--- a/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.html
+++ b/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.html
@@ -6,13 +6,28 @@
                     inputName="icons"
                     [inputListBoxValues]="iconList"
                     [(ngModel)]="iconClass"
-                    (textInputValueChanged)="textInputValue = $event">
+                    (textInputValueChange)="textInputValue = $event">
                 </terra-suggestion-box>
             </div>
             <div class="col-md-4 text-md-left h2">
                 <span [ngClass]="iconClass"></span>
                 <span>{{iconClass}}</span>
                 <span>{{textInputValue}}</span>
+            </div>
+        </div>
+    
+        <div class="row">
+            <div class="col-md-8">
+                <terra-suggestion-box
+                    inputName="Contacts"
+                    [inputListBoxValues]="contactsSuggestions"
+                    [(ngModel)]="selectedContact"
+                    (textInputValueChange)="contactSelectionText = $event">
+                </terra-suggestion-box>
+            </div>
+            <div class="col-md-4 text-md-left h2">
+                <span>{{contactSelectionText}}</span>
+                <span>{{selectedContact | json }}</span>
             </div>
         </div>
     </div>

--- a/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.ts
+++ b/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.ts
@@ -11,13 +11,14 @@ import { TerraSuggestionBoxValueInterface } from '../data/terra-suggestion-box.i
 })
 export class TerraSuggestionBoxComponentExample implements OnInit
 {
-    private _iconList:Array<TerraSuggestionBoxValueInterface> = [];
-    private _iconClass:string;
+    protected textInputValue:string;
+    protected iconList:Array<TerraSuggestionBoxValueInterface> = [];
+    protected iconClass:string;
 
     public ngOnInit():void
     {
-        this._iconClass = 'icon-plugin';
-        this._iconList.push
+        this.iconClass = 'icon-plugin';
+        this.iconList.push
         (
             {
                 value: 'icon-plugin',

--- a/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.ts
+++ b/src/app/components/forms/suggestion-box/example/terra-suggestion-box.component.example.ts
@@ -15,6 +15,24 @@ export class TerraSuggestionBoxComponentExample implements OnInit
     protected iconList:Array<TerraSuggestionBoxValueInterface> = [];
     protected iconClass:string;
 
+    protected contacts:Array<any> = [
+        {
+            name: 'Max Mustermann',
+            age: 28
+        },
+        {
+            name: 'Thomas Schmidt',
+            age: 28
+        },
+        {
+            name: 'Sabrina Meyer',
+            age: 29
+        }
+    ];
+    protected contactsSuggestions:Array<TerraSuggestionBoxValueInterface> = [];
+    protected selectedContact:any;
+    protected contactSelectionText:string;
+
     public ngOnInit():void
     {
         this.iconClass = 'icon-plugin';
@@ -41,5 +59,12 @@ export class TerraSuggestionBoxComponentExample implements OnInit
                 caption: 'icon-flag_blue'
             }
         );
+
+        this.contactsSuggestions = this.contacts.map(contact => {
+            return {
+                caption: contact.name,
+                value: contact
+            };
+        });
     }
 }

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.html
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.html
@@ -11,8 +11,7 @@
      (keydown)="onKeyDown($event)"
      container="body">
     
-    <terra-text-input #textInput
-                      [inputIsDisabled]="inputIsDisabled"
+    <terra-text-input [inputIsDisabled]="inputIsDisabled"
                       [inputName]="inputName"
                       (outputOnInput)="onChange()"
                       (click)="onInputClick($event)"
@@ -32,7 +31,7 @@
         
         <span *ngFor="let item of _displayListBoxValues"
               (click)="select(item)"
-              [ngClass]="{active: item.value === value, selected: item.value === _tmpSelectedValue?.value}">
+              [ngClass]="{active: item.value === selectedValue?.value, selected: item.value === _tmpSelectedValue?.value}">
             <span class="{{item.icon}}" *ngIf="item.icon"></span>
             <img *ngIf="item.imgsrc" src="{{item.imgsrc}}"/>
             <span [innerHtml]="item.caption"></span>

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.html
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.html
@@ -11,11 +11,12 @@
      (keydown)="onKeyDown($event)"
      container="body">
     
-    <terra-text-input [inputIsDisabled]="inputIsDisabled"
+    <terra-text-input #textInput
+                      [inputIsDisabled]="inputIsDisabled"
                       [inputName]="inputName"
                       (outputOnInput)="onChange()"
                       (click)="onInputClick($event)"
-                      [(ngModel)]="selectedValue.caption">
+                      [(ngModel)]="textInputValue">
     </terra-text-input>
     
     <!-- suggestions -->
@@ -31,9 +32,9 @@
         
         <span *ngFor="let item of _displayListBoxValues"
               (click)="select(item)"
-              [ngClass]="{active: item.value === selectedValue?.value, selected: item.value === _tmpSelectedValue?.value}">
+              [ngClass]="{active: item.value === value, selected: item.value === _tmpSelectedValue?.value}">
             <span class="{{item.icon}}" *ngIf="item.icon"></span>
-            <img *ngIf="item.imgsrc" src="{{item.imgsrc}}" />
+            <img *ngIf="item.imgsrc" src="{{item.imgsrc}}"/>
             <span [innerHtml]="item.caption"></span>
         </span>
     </div>

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -381,8 +381,11 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
 
     protected set textInputValue(value:string)
     {
+        if(this._textInputValue !== value)
+        {
+            this.textInputValueChange.emit(value);
+        }
         this._textInputValue = value;
-        this.textInputValueChange.emit(value);
     }
 
     public set selectedValue(value:TerraSuggestionBoxValueInterface)

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -65,16 +65,16 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
     public textInputValueChange:EventEmitter<string> = new EventEmitter<string>();
 
     public isValid:boolean = true;
+
     protected _displayListBoxValues:Array<TerraSuggestionBoxValueInterface> = [];
     protected _lastSelectedValues:Array<TerraSuggestionBoxValueInterface> = [];
     protected _listBoxHeadingKey:string = '';
     protected _noEntriesTextKey:string;
+    protected _selectedValue:TerraSuggestionBoxValueInterface = null;
+    protected _tmpSelectedValue:TerraSuggestionBoxValueInterface = null;
+    protected _textInputValue:string;
+    protected _toggleOpen:boolean = false;
 
-    private _selectedValue:TerraSuggestionBoxValueInterface = null;
-    private _tmpSelectedValue:TerraSuggestionBoxValueInterface = null;
-    private _textInputValue:string;
-    private _toggleOpen:boolean = false;
-    private _hasLabel:boolean;
     private clickListener:(event:Event) => void;
 
     constructor(private _elementRef:ElementRef)
@@ -88,7 +88,6 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
             this.clickedOutside(event);
         };
 
-        this._hasLabel = !isNull(this.inputName);
         this._noEntriesTextKey = this.inputWithRecentlyUsed ? 'terraSuggestionBox.noRecentlyUsed' : 'terraSuggestionBox.noSuggestions';
 
         if(!this.inputWithRecentlyUsed)
@@ -103,10 +102,9 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
         if(changes['inputListBoxValues'])
         {
             this._displayListBoxValues = this.inputListBoxValues;
-            if(changes['inputListBoxValues'].currentValue.length > 0
-               && !this.inputListBoxValues.find((x:TerraSuggestionBoxValueInterface):boolean => this.selectedValue === x))
+            if(!this.inputListBoxValues.find((x:TerraSuggestionBoxValueInterface):boolean => this.selectedValue === x))
             {
-                // reset selected value if the list is empty
+                // reset selected value if the value does not exists or the list is empty
                 this.selectedValue = null;
             }
         }

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -260,6 +260,14 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
         this.selectedValue = this._displayListBoxValues.find((val:TerraSuggestionBoxValueInterface) => val.caption === searchString);
     }
 
+    /**
+     * @deprecated use ngModel instead to reset the selected value
+     */
+    public resetComponentValue():void
+    {
+        this.selectedValue = null;
+    }
+
     protected onKeyDown(event:KeyboardEvent):void
     {
         // check if one of the dedicated keys has been pressed

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -387,20 +387,24 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
 
     public set selectedValue(value:TerraSuggestionBoxValueInterface)
     {
-        // update local model
-        this._selectedValue = value;
-        this._tmpSelectedValue = this._selectedValue;
-
-        // update text input value
-        if(!isNullOrUndefined(this._selectedValue))
+        // the value has changed?
+        if(this._selectedValue !== value)
         {
-            this.textInputValue = this._selectedValue.caption;
-        }
+            // update local model
+            this._selectedValue = value;
+            this._tmpSelectedValue = this._selectedValue;
 
-        // execute callback functions
-        this.onTouchedCallback();
-        this.onChangeCallback(this.value);
-        this.outputValueChanged.emit(this._selectedValue);
+            // update text input value
+            if(!isNullOrUndefined(this._selectedValue))
+            {
+                this.textInputValue = this._selectedValue.caption;
+            }
+
+            // execute callback functions
+            this.onTouchedCallback(); // this may be called when the text input value changes instead!?
+            this.onChangeCallback(this.value);
+            this.outputValueChanged.emit(this._selectedValue);
+        }
     }
 
     public get selectedValue():TerraSuggestionBoxValueInterface

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -55,6 +55,9 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges
     @Input()
     public inputWithRecentlyUsed:boolean;
 
+    /**
+     * @deprecated since it notifies the user at exactly the same time as ngModelChange <-> onChangeCallback
+     */
     @Output()
     public outputValueChanged:EventEmitter<TerraSuggestionBoxValueInterface> = new EventEmitter<TerraSuggestionBoxValueInterface>();
 

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -11,10 +11,7 @@ import {
 } from '@angular/core';
 import { TerraSuggestionBoxValueInterface } from './data/terra-suggestion-box.interface';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import {
-    isNull,
-    isNullOrUndefined
-} from 'util';
+import { isNullOrUndefined } from 'util';
 import { TerraPlacementEnum } from '../../../helpers/enums/terra-placement.enum';
 import { TerraBaseData } from '../../data/terra-base.data';
 


### PR DESCRIPTION
This PR actually includes various improvements:
* New Output `textInputValueChange` that emits the current text input value
* Select a Value from the suggestions if the entered text matches its caption
* `selectedValue` is reset if `inputListBoxValues` is updated and the previous selected element is not present anymore
* `selectedValue = null` if entered text does not match any of the `inputListBoxValues`
* `resetComponentValue`-Method is now deprecated. Use `ngModel` instead to set the value to `null`
* `outputValueChanged` is now deprecated. Use `ngModelChange` instead.