### PR TITLE
fix (suggestion-box): prevent execution of ngModelChange-Callback...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Bug Fixes
+* **terra-suggestion-box** prevent execution of `ngModelChange`-Callback if value changes from `undefined` to `null` or reverse.
+
 <a name="2.3.12"></a>
 # 2.3.12 (20.08.2018)
 

--- a/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
+++ b/src/app/components/forms/suggestion-box/terra-suggestion-box.component.ts
@@ -393,6 +393,11 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges, ControlVa
 
     public set selectedValue(value:TerraSuggestionBoxValueInterface)
     {
+        // does not do anything if the value changes from undefined to null or reverse
+        if(isNullOrUndefined(this._selectedValue) && isNullOrUndefined(value))
+        {
+            return;
+        }
         // the value has changed?
         if(this._selectedValue !== value)
         {
@@ -400,16 +405,17 @@ export class TerraSuggestionBoxComponent implements OnInit, OnChanges, ControlVa
             this._selectedValue = value;
             this._tmpSelectedValue = this._selectedValue;
 
-            // update text input value
-            if(!isNullOrUndefined(this._selectedValue))
-            {
-                this.textInputValue = this._selectedValue.caption;
-            }
-
             // execute callback functions
             this.onTouchedCallback(); // this may be called when the text input value changes instead!?
             this.onChangeCallback(this.value);
             this.outputValueChanged.emit(this._selectedValue);
+
+            // finally update text input value
+            // This needs to be done after executing the callbacks to make a live search work!!
+            if(!isNullOrUndefined(this._selectedValue))
+            {
+                this.textInputValue = this._selectedValue.caption;
+            }
         }
     }
 


### PR DESCRIPTION
.. if the value changes from `undefined` to `null` or reverse

@plentymarkets/team-terra 