### PR TITLE
fix (terra-node-tree.config): issue with access modifier in extended classes

### DIFF
--- a/src/app/components/tree/node-tree/data/terra-node-tree.config.ts
+++ b/src/app/components/tree/node-tree/data/terra-node-tree.config.ts
@@ -12,7 +12,7 @@ export class TerraNodeTreeConfig<D>
     protected _currentSelectedNode:TerraNodeInterface<D>;
     private _list:Array<TerraNodeInterface<D>> = [];
 
-    constructor(private translation:TranslationService)
+    constructor(protected translation:TranslationService)
     {
 
     }


### PR DESCRIPTION
Currently there is a compilation error with beta7..

@plentymarkets/team-terra

### Definition of Done

Testing
- [x] Person 1
- [x] Person 2

In Order to test this you need to switch to the branch https://github.com/plentymarkets/terra-components/tree/fix/node-tree_config/access_modifier_translation_beta_3.0.0 and temporarily adjust the constructor of the `SystemTreeConfig` in Terra on beta7 =>

```
constructor(private router:Router,
                translation:TranslationService,
                private permissionsService:PermissionsService,
                private systemPermissionsService:SystemPermissionsService,
                private globalRegistry:GlobalRegistryService,
                private keywordsService:SystemKeywordsService)
    {
        super(translation);

        this.pluginNodes = [];
        this.routeConfig = this.router.config as TerraRoutes;
    }
```


