### PR TITLE
fix(terra-select-box):fixed broken padding on compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Bug Fixes
 * **tooltips** tooltip color in light theme is now dark for better contrast
-* **terra-select-box** updated padding
+* **terra-select-box** fixed padding on compact mode
 
 <a name="3.7.0-beta.2"></a>
 # 3.7.0-beta.2 (14.03.2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Bug Fixes
 * **tooltips** tooltip color in light theme is now dark for better contrast
+* **terra-select-box** updated padding
 
 <a name="3.7.0-beta.2"></a>
 # 3.7.0-beta.2 (14.03.2019)

--- a/src/app/components/forms/select-box/terra-select-box.component.scss
+++ b/src/app/components/forms/select-box/terra-select-box.component.scss
@@ -75,7 +75,6 @@
         &.labeled
         {
             padding: var(--select-box-labeled-padding, var(--select-box-labeled-padding-default));
-            padding-left: var(--select-box-labeled-padding-left, initial);
             transition: padding var(--transition-lg);
             
             span


### PR DESCRIPTION
@plentymarkets/team-terra
<img width="555" alt="before" src="https://user-images.githubusercontent.com/10026004/54912314-ab072300-4ef0-11e9-8bbe-4cdc90b372d0.png">
<img width="555" alt="after" src="https://user-images.githubusercontent.com/10026004/54912420-e6a1ed00-4ef0-11e9-9442-07176b306244.png">


### Definition of Done
Documentation
- [x] Changelog

Testing
- [x] Unit Test successful
- [x] Person 1
- [ ] Person 2

Browser-Support
- [x] Chrome
- [x] Firefox
- [x] Safari