### PR TITLE
fix(node-tree): access modifier for TranslationService

### DIFF
--- a/src/lib/components/tree/node-tree/data/terra-node-tree.config.ts
+++ b/src/lib/components/tree/node-tree/data/terra-node-tree.config.ts
@@ -11,7 +11,7 @@ export class TerraNodeTreeConfig<D>
     protected _currentSelectedNode:TerraNodeInterface<D>;
     private _list:Array<TerraNodeInterface<D>> = [];
 
-    constructor(protected _translation:TranslationService)
+    constructor(public translation:TranslationService)
     {
     }
 


### PR DESCRIPTION
...since it is not backwards compatible. When trying to install the latest release in terra the following error occurs:

![Bildschirmfoto 2019-10-24 um 10 14 13](https://user-images.githubusercontent.com/26869118/67466294-1b248580-f647-11e9-9c31-86def9890cda.png)
