### PR TITLE
feature(terra-toggle-component):added color to disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # 4.8.0 (XX.XX.XXXX)
 
 ### Features
+* **terra-toggle** Added active/inactive color to disabled state.
 * **terra-portlet** Now supports styling of info-boxes and tables inside it.
 
 ### Bug Fixes

--- a/src/lib/components/buttons/toggle/terra-toggle.component.scss
+++ b/src/lib/components/buttons/toggle/terra-toggle.component.scss
@@ -34,6 +34,18 @@
 
     &.active
     {
+        &.disabled
+        {
+            .slider
+            {
+                &:before
+                {
+                    background-color: var(--color-add);
+                    opacity: .5;
+                }
+            }
+        }
+        
         .slider
         {
             &:before
@@ -52,7 +64,8 @@
         {
             &:before
             {
-                background-color: var(--color-structure-3);
+                background-color: var(--color-alert);
+                opacity: .25;
             }
         }
     }


### PR DESCRIPTION
@plentymarkets/team-terra
<img width="539" alt="new-toggle-colors" src="https://user-images.githubusercontent.com/10026004/69335250-c7fd1d00-0c5c-11ea-9abe-114c490ae7c9.png">


<img width="597" alt="toggle-old" src="https://user-images.githubusercontent.com/10026004/69335353-0c88b880-0c5d-11ea-8cc4-b7d92e6c6c7a.png">


### Definition of Done

#### Must be done by Terra

Testing
- [x] Person 1 (mandatory)
- [x] Person 2 (mandatory)

Browser-Support (relevant for changes in scss / appearance of components and jQuery)
- [x] Chrome
- [x] Safari
- [x] Firefox

#### Must be done by every developer
Please inform a member of Terra (@plentymarkets/team-terra) to get the upper part of the checklist done (with urgency or deadline). 

Documentation
- [x] Changelog (optional: relevant for every change which influences the API)