### PR TITLE
[FIX] Removed negative margins from container that are nested in a portlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="4.8.1"></a>
+# 4.8.1 (Unreleased)
+
+### Bug Fixes
+ * **terra-portlets** removed negative margins from nested containers (portlets, toolbars, tables, infoboxes, pager)
+
 <a name="4.8.0"></a>
 # 4.8.0 (20.12.2019)
 

--- a/src/lib/components/layouts/portlet/terra-portlet.component.scss
+++ b/src/lib/components/layouts/portlet/terra-portlet.component.scss
@@ -2,7 +2,7 @@
 {
     border-radius: var(--border-radius);
     margin: var(--space-container);
-    box-shadow: var(--box-shadow);
+    box-shadow: var(--portlet-box-shadow, var(--box-shadow));
 
     .portlet-head
     {
@@ -42,27 +42,12 @@
         padding: var(--portlet-body-padding, var(--space-lg));
         transition: padding var(--transition-lg);
         border-radius: var(--border-radius);
-        
-        --portlet-body-reverse-container-margin: calc(var(--space-lg)*(-1)) calc(var(--space-lg)*(-1)) var(--space-lg) calc(var(--space-lg)*(-1));
-        //Infobox
+    
+        --portlet-box-shadow: none;
         --info-box-box-shadow: none;
-        --info-box-margin: var(--portlet-body-reverse-container-margin);
-        --info-box-border-bottom: 1px solid var(--color-structure-2);
-        
-        //Table
-        --pager-margin: 0;
         --pager-box-shadow: none;
-        --pager-border-bottom: 1px solid var(--color-structure-2);
-        --pager-border-top: 1px solid var(--color-structure-2);
-        
-        --terra-data-table-margin: var(--portlet-body-reverse-container-margin);
-        --table-responsive-margin: 0;
         --table-responsive-box-shadow: none;
-        
-        //Toolbar
-        --toolbar-margin: var(--portlet-body-reverse-container-margin);
-        --toolbar-box-shadow: 0;
-        --toolbar-border-bottom: 1px solid var(--color-structure-2);
+        --toolbar-box-shadow: none;
     }
 
     &.collapsable


### PR DESCRIPTION
@plentymarkets/team-terra

### Definition of Done

#### Must be done by Terra

Testing
- [x] Person 1 (mandatory)
- [ ] Person 2 (mandatory)

Documentation
- [x] Changelog (optional: relevant for every change which influences the API)

Vorher
<img width="1440" alt="71255213-95167980-232d-11ea-8862-18279c971f52" src="https://user-images.githubusercontent.com/25303993/71821626-e004f080-3092-11ea-8407-f25a8739eb9c.png">

Nachher
<img width="1440" alt="Bildschirmfoto 2020-01-06 um 14 44 08" src="https://user-images.githubusercontent.com/25303993/71821633-e85d2b80-3092-11ea-81a0-9840f10cfd97.png">

<img width="1423" alt="Bildschirmfoto 2020-01-06 um 14 18 49" src="https://user-images.githubusercontent.com/25303993/71820427-543d9500-308f-11ea-853f-5c7f5a290962.png">