### PR TITLE
fix(terra-portlet):remove overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **terraResizable** deprecate directive.
 
 ### Bug Fixes
+* **terra-portlet** removed overflow
 * **terra-node-tree** fixed error that was thrown when the user searches for a node and one of the node's name was undefined.
 * **terra-two-columns-container** updated outer paddings
 * **terra-three-columns-container** updated outer paddings

--- a/src/lib/components/layouts/portlet/terra-portlet.component.scss
+++ b/src/lib/components/layouts/portlet/terra-portlet.component.scss
@@ -8,6 +8,7 @@
     {
         padding: var(--space-md) var(--space-lg);
         background: var(--color-structure-0);
+        overflow-x: hidden;
 
         display: -webkit-flex; /* Safari */
         -webkit-justify-content: flex-start; /* Safari 6.1+ */
@@ -46,6 +47,7 @@
         padding: var(--portlet-body-padding, var(--space-lg));
         transition: padding var(--transition-lg);
         border-radius: var(--border-radius);
+        overflow-x: hidden;
     
         --portlet-box-shadow: none;
         --info-box-box-shadow: none;


### PR DESCRIPTION
@plentymarkets/team-terra

<img width="757" alt="portlet-x-overflow" src="https://user-images.githubusercontent.com/10026004/79380322-94e75d00-7f60-11ea-9c9d-ab2dcbacf707.png">


### Definition of Done

#### Must be done by Terra

Testing
- [x] Person 1 (mandatory)

    Browser-Support (relevant for changes in scss / appearance of components and jQuery)
    - [x] Chrome
    - [ ] Firefox
    - [ ] Safari
    
    Responsiveness
    - [x] Desktop
    - [ ] Tablet
    - [ ] Mobile
    
- [ ] Person 2 (mandatory)

    Browser-Support
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    
    Responsiveness
    - [ ] Desktop
    - [ ] Tablet
    - [ ] Mobile

Documentation
- [x] Changelog (optional: relevant for every change which influences the API)