### PR TITLE
feature: code coverage badge for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![code coverage](https://img.shields.io/badge/coverage-46.29%25-red)
 [![npm version](https://badge.fury.io/js/%40plentymarkets%2Fterra-components.svg)](https://badge.fury.io/js/%40plentymarkets%2Fterra-components)
 
 ![plentymarkets Logo](http://www.plentymarkets.eu/layout/pm/images/logo/plentymarkets-logo.jpg)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![code coverage](https://img.shields.io/badge/coverage-46.29%25-red)
+![code coverage](https://img.shields.io/badge/coverage-46.35%25-red)
 [![npm version](https://badge.fury.io/js/%40plentymarkets%2Fterra-components.svg)](https://badge.fury.io/js/%40plentymarkets%2Fterra-components)
 
 ![plentymarkets Logo](http://www.plentymarkets.eu/layout/pm/images/logo/plentymarkets-logo.jpg)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ function coverageBadge(done) {
     const readme = fs.readFileSync('README.md');
     const eol = readme.indexOf('\n');
     const readmeString = readme.toString();
-    const currentBadge = readmeString.slice(0, eol - 1).replace('![code coverage](', '');
+    const currentBadge = readmeString.slice(0, eol);
     if(!badgeUrlTemplate.test(currentBadge))
     {
         throw 'Failed to update badge. No coverage badge available in line 1 of the README.md';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,21 @@ const sass = require('gulp-sass');
 const tildeImporter = require('node-sass-tilde-importer');
 
 
+function generateBadgeUrl() {
+    const coverageSummary = fs.readFileSync('./coverage/coverage-summary.json', { encoding: 'utf8'});
+    const coverageJSON = JSON.parse(coverageSummary);
+    const coveragePct = coverageJSON.total.lines.pct;
+    const color = coveragePct > 80 ? 'brightgreen' : coveragePct > 50 ? 'yellow' : 'red';
+    return 'https://img.shields.io/badge/coverage-' + encodeURIComponent(`${coveragePct}%-${color}`);
+}
+
+function coverageBadge(done) {
+    const badgeUrl = generateBadgeUrl();
+    console.log(badgeUrl);
+    done();
+}
+exports.coverageBadge = coverageBadge;
+
 // convert global scss styles to css files
 function compileGlobalStyles() {
     return src(config.sources.scss)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,21 +6,29 @@ const argv = require('yargs').argv;
 const sass = require('gulp-sass');
 const tildeImporter = require('node-sass-tilde-importer');
 
-
-function generateBadgeUrl() {
+function getCoverage() {
     const coverageSummary = fs.readFileSync('./coverage/coverage-summary.json', { encoding: 'utf8'});
     const coverageJSON = JSON.parse(coverageSummary);
-    const coveragePct = coverageJSON.total.lines.pct;
-    const color = coveragePct > 80 ? 'brightgreen' : coveragePct > 50 ? 'yellow' : 'red';
-    return 'https://img.shields.io/badge/coverage-' + encodeURIComponent(`${coveragePct}%-${color}`);
+    return coverageJSON.total.lines.pct;
+}
+
+function generateBadgeUrl(coverage) {
+
+    const color = coverage > 80 ? 'brightgreen' : coverage > 50 ? 'yellow' : 'red';
+    return 'https://img.shields.io/badge/coverage-' + encodeURIComponent(`${coverage}%-${color}`);
 }
 
 function coverageBadge(done) {
-    const badgeUrl = generateBadgeUrl();
+    const coverage = getCoverage();
+    const badgeUrl = generateBadgeUrl(coverage);
     const badgeTemplate = `![code coverage](${badgeUrl})`;
     const readme = fs.readFileSync('README.md');
     const eol = readme.indexOf('\n');
     const readmeString = readme.toString();
+    if(!readmeString.slice(0, eol).startsWith('![code coverage]'))
+    {
+        throw 'Failed to update badge. No coverage badge available in line 1 of the README.md';
+    }
     const newReadmeString = badgeTemplate + readmeString.slice(eol);
     fs.writeFileSync('README.md', newReadmeString);
     done();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,12 @@ function generateBadgeUrl() {
 
 function coverageBadge(done) {
     const badgeUrl = generateBadgeUrl();
-    console.log(badgeUrl);
+    const badgeTemplate = `![code coverage](${badgeUrl})`;
+    const readme = fs.readFileSync('README.md');
+    const eol = readme.indexOf('\n');
+    const readmeString = readme.toString();
+    const newReadmeString = badgeTemplate + readmeString.slice(eol);
+    fs.writeFileSync('README.md', newReadmeString);
     done();
 }
 exports.coverageBadge = coverageBadge;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,10 +25,9 @@ function updateCoverageBadge(done) {
     const coverage = getCoverage();
     const badgeUrl = generateBadgeUrl(coverage);
     const badge = `![code coverage](${badgeUrl})`;
-    const readme = fs.readFileSync('README.md');
+    const readme = fs.readFileSync('README.md', { encoding: 'utf8'});
     const eol = readme.indexOf('\n');
-    const readmeString = readme.toString();
-    const currentBadge = readmeString.slice(0, eol);
+    const currentBadge = readme.slice(0, eol);
     if(!badgeUrlTemplate.test(currentBadge))
     {
         throw 'Failed to update badge. No coverage badge available in line 1 of the README.md';
@@ -37,7 +36,7 @@ function updateCoverageBadge(done) {
     {
         throw `Failed to update badge. New badge doesn't comply to the badge template`;
     }
-    const newReadmeString = badge + readmeString.slice(eol);
+    const newReadmeString = badge + readme.slice(eol);
     fs.writeFileSync('README.md', newReadmeString);
     done();
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ function generateBadgeUrl(coverage) {
     return badgeUrlPrefix + encodeURIComponent(`${'coverage'}-${coverage}%-${color}`);
 }
 
-function coverageBadge(done) {
+function updateCoverageBadge(done) {
     const coverage = getCoverage();
     const badgeUrl = generateBadgeUrl(coverage);
     const badge = `![code coverage](${badgeUrl})`;
@@ -41,7 +41,7 @@ function coverageBadge(done) {
     fs.writeFileSync('README.md', newReadmeString);
     done();
 }
-exports.coverageBadge = coverageBadge;
+exports.updateCoverageBadge = updateCoverageBadge;
 
 // convert global scss styles to css files
 function compileGlobalStyles() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, './coverage'),
-      reports: ['html', 'lcovonly'],
+      reports: ['html', 'json-summary'],
       fixWebpackSourcePaths: true
     },
     customLaunchers: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
 		"test-once": "ng test lib --watch=false --browsers=Chrome,Firefox,Safari",
 		"test-headless": "ng test lib --watch=false --browsers=ChromeHeadless,FirefoxHeadless",
 		"test:coverage": "ng test lib --watch=false --browsers=ChromeHeadless --codeCoverage",
-		"coverage-badge": "gulp updateCoverageBadge",
 		"lint": "ng lint lib",
 		"reinstall": "npm ci",
 		"prepare-release": "npm run reinstall && npm run build && npm run test-once && npm start"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"test": "ng test lib",
 		"test-once": "ng test lib --watch=false --browsers=Chrome,Firefox,Safari",
 		"test-headless": "ng test lib --watch=false --browsers=ChromeHeadless,FirefoxHeadless",
-		"test:coverage": "ng test lib --watch=false --browsers=ChromeHeadless --codeCoverage",
+		"badge:coverage": "ng test lib --watch=false --browsers=ChromeHeadless --codeCoverage && gulp updateCoverageBadge",
 		"lint": "ng lint lib",
 		"reinstall": "npm ci",
 		"prepare-release": "npm run reinstall && npm run build && npm run test-once && npm start"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 		"test": "ng test lib",
 		"test-once": "ng test lib --watch=false --browsers=Chrome,Firefox,Safari",
 		"test-headless": "ng test lib --watch=false --browsers=ChromeHeadless,FirefoxHeadless",
+		"test:coverage": "ng test lib --watch=false --browsers=ChromeHeadless --codeCoverage",
+		"coverage-badge": "gulp coverageBadge",
 		"lint": "ng lint lib",
 		"reinstall": "npm ci",
 		"prepare-release": "npm run reinstall && npm run build && npm run test-once && npm start"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test-once": "ng test lib --watch=false --browsers=Chrome,Firefox,Safari",
 		"test-headless": "ng test lib --watch=false --browsers=ChromeHeadless,FirefoxHeadless",
 		"test:coverage": "ng test lib --watch=false --browsers=ChromeHeadless --codeCoverage",
-		"coverage-badge": "gulp coverageBadge",
+		"coverage-badge": "gulp updateCoverageBadge",
 		"lint": "ng lint lib",
 		"reinstall": "npm ci",
 		"prepare-release": "npm run reinstall && npm run build && npm run test-once && npm start"


### PR DESCRIPTION
Using this badge generator: https://shields.io/category/coverage
Running `npm run badge:coverage` prints a badge to our README.md with the latest coverage.