### PR TITLE
feature(accessibility): change selectors for a better screen readability

### DIFF
--- a/src/lib/components/forms/form/example/terra-form.component.example.html
+++ b/src/lib/components/forms/form/example/terra-form.component.example.html
@@ -1,4 +1,4 @@
-<b [style.color]="form.formGroup.valid ? 'green' : 'red'">{{form.formGroup.status}}</b>
+<strong [style.color]="form.formGroup.valid ? 'green' : 'red'">{{form.formGroup.status}}</strong>
 <terra-portlet>
     <terra-form #form [inputControlTypeMap]="_formTypeMap" [inputFormFields]="_formFields" [(ngModel)]="_formValue">
     </terra-form>

--- a/src/lib/components/forms/suggestion-box/terra-suggestion-box.component.html
+++ b/src/lib/components/forms/suggestion-box/terra-suggestion-box.component.html
@@ -22,7 +22,7 @@
     <!-- suggestions -->
     <div class="select-box-dropdown">
         <span *ngIf="_displayListBoxValues.length === 0" (click)="$event.stopPropagation()">
-            <i>{{ _noEntriesTextKey | translate: _locale.language }} </i>
+            <em>{{ _noEntriesTextKey | translate: _locale.language }} </em>
         </span>
 
         <span
@@ -31,7 +31,7 @@
             (click)="$event.stopPropagation()"
         >
             <i
-                ><b> {{ _listBoxHeadingKey | translate: _locale.language }} </b></i
+                ><strong> {{ _listBoxHeadingKey | translate: _locale.language }} </strong></i
             >
         </span>
 

--- a/src/lib/components/info/example/terra-info.component.example.html
+++ b/src/lib/components/info/example/terra-info.component.example.html
@@ -3,7 +3,7 @@
         <div class="col-md-6">
             <h2>Tooltip placement right</h2>
             <terra-info
-                [text]="'This <b>information</b> will be used for...'"
+                [text]="'This <strong>information</strong> will be used for...'"
                 [textPlacement]="_tooltipPlacement"
             ></terra-info>
         </div>
@@ -25,7 +25,7 @@
             <div class="d-flex">
                 <terra-text-input inputName="address"></terra-text-input>
                 <terra-info
-                    [text]="'This <i>information</i> will be used for...'"
+                    [text]="'This <em>information</em> will be used for...'"
                     [textPlacement]="_tooltipPlacement"
                 ></terra-info>
             </div>


### PR DESCRIPTION
@plentymarkets/team-terra

```
The <strong>/<b> and <em>/<i> tags have exactly the same effect in most web browsers, but there is a fundamental difference between them: <strong> and <em> have a semantic meaning whereas <b> and <i> only convey styling information like CSS.

While <b> can have simply no effect on a some devices with limited display or when a screen reader software is used by a blind person, <strong> will:

Display the text bold in normal browsers
Speak with lower tone when using a screen reader such as Jaws
```

### Definition of Done

#### Must be done by Terra

Testing

-   [ ] Person 1 (mandatory)

    Browser-Support (relevant for changes in scss / appearance of components)

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

-   [ ] Person 2 (mandatory)

    Browser-Support

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

---

#### Must be done by every developer

Please inform a member of Terra (@plentymarkets/team-terra) to get the upper part of the checklist done (with urgency or deadline).

Documentation

-   [ ] Changelog (optional: relevant for every change which influences the API)

Testing

-   [ ] Unit Test (updated or created)
