### PR TITLE
fix (terra-node): remove margin to reduce overflow in terra-node-tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.X.X (XX.XX.XXXX) UNRELEASED
+
+### Bug Fixes
+
+-   **terra-node-tree** fixed the horizontal scrollbar.
+
 # 6.0.0 (10.02.2021)
 
 ### Breaking Changes
@@ -6,10 +12,6 @@
 -   **terra-node-tree** removed dependency to `TranslationService` from `TerraNodeTreeConfig`.
 -   **terra-nested-data-picker** removed dependency to `TranslationService` from `NestedDataTreeConfig`.
 -   **terra-category-picker** removed dependency to `TranslationService` from `CategoryTreeConfig`.
-
-### Bug Fixes
-
--   **terra-node-tree** fixed the horizontal scrollbar.
 
 # 6.0.0-beta.2 (21.01.2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   **terra-nested-data-picker** removed dependency to `TranslationService` from `NestedDataTreeConfig`.
 -   **terra-category-picker** removed dependency to `TranslationService` from `CategoryTreeConfig`.
 
+### Bug Fixes
+
+-   **terra-node-tree** fixed the horizontal scrollbar.
+
 # 6.0.0-beta.2 (21.01.2021)
 
 ### Breaking Changes

--- a/src/lib/components/tree/node-tree/node/terra-node.component.scss
+++ b/src/lib/components/tree/node-tree/node/terra-node.component.scss
@@ -7,6 +7,7 @@ li {
 
     .btn-handler {
         width: 100%;
+        margin-right: 0 !important;
 
         .btn {
             text-align: left;


### PR DESCRIPTION
![Bildschirmfoto 2021-02-15 um 16 35 28](https://user-images.githubusercontent.com/47743312/108033324-1e116980-7034-11eb-88d4-e1fbf60609f8.png)


@plentymarkets/team-terra

### Definition of Done

#### Must be done by Terra

Testing

-   [ ] Person 1 (mandatory)

    Browser-Support (relevant for changes in scss / appearance of components)

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

-   [ ] Person 2 (mandatory)

    Browser-Support

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

Documentation

-   [x] Changelog (optional: relevant for every change which influences the API)