### PR TITLE
feature(form): required true validation error message

### DIFF
--- a/src/lib/components/forms/form/form-components/checkbox/checkbox.component.html
+++ b/src/lib/components/forms/form/form-components/checkbox/checkbox.component.html
@@ -8,7 +8,11 @@
     [(indeterminate)]="isIndeterminate"
     cdkMonitorElementFocus
     (cdkFocusChange)="_onFocusChange($event)"
+    #control="ngModel"
 >
     <mat-icon *ngIf="icon" fontSet="plentyicons" [fontIcon]="icon"></mat-icon>
     {{ name }}
 </mat-checkbox>
+<mat-error *ngIf="control.touched && control.hasError('required')">
+    {{ 'validators.required' | translate: _lang }}
+</mat-error>

--- a/src/lib/components/forms/form/form-components/checkbox/checkbox.component.spec.ts
+++ b/src/lib/components/forms/form/form-components/checkbox/checkbox.component.spec.ts
@@ -11,6 +11,9 @@ import { FormsModule } from '@angular/forms';
 import { MatIconHarness } from '@angular/material/icon/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { A11yModule } from '@angular/cdk/a11y';
+import { L10N_LOCALE, L10nTranslationModule } from 'angular-l10n';
+import { mockL10nConfig } from '../../../../../testing/mock-l10n-config';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 // tslint:disable-next-line:max-function-line-count
 describe('CheckboxComponent', () => {
@@ -21,8 +24,16 @@ describe('CheckboxComponent', () => {
 
     beforeEach(async () => {
         TestBed.configureTestingModule({
-            imports: [MatCheckboxModule, FormsModule, MatIconModule, A11yModule],
-            declarations: [CheckboxComponent, MockTooltipDirective]
+            imports: [
+                MatCheckboxModule,
+                FormsModule,
+                MatIconModule,
+                A11yModule,
+                L10nTranslationModule.forRoot(mockL10nConfig),
+                MatFormFieldModule
+            ],
+            declarations: [CheckboxComponent, MockTooltipDirective],
+            providers: [{ provide: L10N_LOCALE, useValue: 'de' }]
         });
 
         fixture = TestBed.createComponent(CheckboxComponent);
@@ -145,5 +156,19 @@ describe('CheckboxComponent', () => {
 
             expect(tooltip.tcTooltip).toBe('test');
         });
+    });
+
+    it('should display an error message when it is not checked, but required and touched ', async () => {
+        component.isRequired = true;
+        fixture.detectChanges();
+        expect(await checkbox.isChecked()).toBe(false);
+
+        await checkbox.focus();
+        await checkbox.blur();
+        fixture.detectChanges();
+
+        const error: HTMLElement = fixture.debugElement.query(By.css('mat-error'))?.nativeElement;
+        expect(error).toBeTruthy();
+        expect(error.textContent.trim()).toBe('validators.required');
     });
 });

--- a/src/lib/components/forms/form/form-components/checkbox/checkbox.component.spec.ts
+++ b/src/lib/components/forms/form/form-components/checkbox/checkbox.component.spec.ts
@@ -24,7 +24,14 @@ describe('CheckboxComponent', () => {
 
     beforeEach(async () => {
         TestBed.configureTestingModule({
-            imports: [MatCheckboxModule, FormsModule, MatIconModule, A11yModule, L10nTranslationModule, MatFormFieldModule],
+            imports: [
+                MatCheckboxModule,
+                FormsModule,
+                MatIconModule,
+                A11yModule,
+                L10nTranslationModule,
+                MatFormFieldModule
+            ],
             providers: [
                 {
                     provide: L10nTranslationService,

--- a/src/lib/components/forms/form/form-components/checkbox/checkbox.component.ts
+++ b/src/lib/components/forms/form/form-components/checkbox/checkbox.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { Component, Inject, Input } from '@angular/core';
 import { TerraPlacementEnum } from '../../../../../helpers';
 import { noop } from 'rxjs';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CheckboxInterface } from './checkbox.interface';
 import { FocusOrigin } from '@angular/cdk/a11y';
+import { L10N_LOCALE, L10nLocale } from 'angular-l10n';
 
 @Component({
     selector: 'tc-checkbox',
@@ -61,6 +62,13 @@ export class CheckboxComponent implements ControlValueAccessor, CheckboxInterfac
 
     /** @description Internal model. The value of the checkbox. */
     public value: boolean;
+
+    /** @description Current language to be used to translate any labels. */
+    public _lang: string;
+
+    constructor(@Inject(L10N_LOCALE) locale: L10nLocale) {
+        this._lang = locale.language;
+    }
 
     /** @description Writes a new value to the element.*/
     public writeValue(value: boolean): void {


### PR DESCRIPTION
Unfortunately, the checkbox can not be used within an angular material form-field. (see https://github.com/angular/components/issues/7891 for further information)

Hence, the error message will simply be shown below the checkbox, as it can be seen in the following screenshot:

<img width="168" alt="Bildschirmfoto 2021-06-17 um 14 31 21" src="https://user-images.githubusercontent.com/26869118/122396851-b420b680-cf78-11eb-996b-c287f0a31649.png">

@plentymarkets/team-terra

### Definition of Done

#### Must be done by Terra

Testing

-   [ ] Person 1 (mandatory)

    Browser support (relevant for changes in scss / appearance of components)

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

-   [ ] Person 2 (mandatory)

    Browser support

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

Information transfer

-   [ ] Inform Ceres about changes in `TerraFormComponent` (optional: relevant for changes in this component)

Terra Basic Plugin

-   [ ] Adapt changes (optional: relevant for version updates, global design changes, l10n)

---

#### Must be done by every developer

Please inform a member of Terra (@plentymarkets/team-terra) to get the upper part of the checklist done (with urgency or deadline).

Documentation

-   [ ] Changelog (optional: relevant for every change which influences the API)
-   [ ] Example (updated or created)
-   [ ] JSDoc (optional: relevant for every change which influences the API)
-   [ ] [Google spreadsheet](https://docs.google.com/spreadsheets/d/1OINnux8TEoitV-qdAxqUQaf9oGI_fqFVwfRWenRFfhI/edit#gid=0) (relevant when deprecating public APIs or features)

Testing

-   [ ] Unit Test (updated or created)
