### PR TITLE
fix(form): support legacy input names on new form components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
--   **terra-form** added support for legacy input names on the new form components.
+-   **terra-form** support legacy input names on the new form components.
 
 # 11.5.0 (23.06.2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 11.5.1 (XX.XX.2021)
+
+### Bug fixes
+
+-   **terra-form** added support for legacy input names on the new form components.
+
 # 11.5.0 (23.06.2021)
 
 ### Features

--- a/src/lib/components/forms/form/example/form-fields.ts
+++ b/src/lib/components/forms/form/example/form-fields.ts
@@ -178,7 +178,7 @@ export const formFields: TerraKeyValueInterface<TerraFormFieldInterface> = {
             name: 'Slider',
             showMinMax: true,
             min: 0,
-            max: 1,
+            inputMax: 2, // legacy
             interval: 0.1,
             showTicks: true,
             precision: 2

--- a/src/lib/components/forms/form/form-entry/terra-form-entry.base.ts
+++ b/src/lib/components/forms/form/form-entry/terra-form-entry.base.ts
@@ -129,6 +129,11 @@ export class TerraFormEntryBase implements OnChanges, OnDestroy {
             this._componentInstance[inputMap[optionKey]] = this.inputFormField.options[optionKey];
         } else if (inputPropertyNames.indexOf(optionKey) >= 0) {
             this._componentInstance[optionKey] = this.inputFormField.options[optionKey];
+        }
+        // this is for the support of legacy input names
+        else if (optionKey.startsWith('input') && inputPropertyNames.includes(this._removeInputPrefix(optionKey))) {
+            const unprefixedOptionKey: string = this._removeInputPrefix(optionKey);
+            this._componentInstance[unprefixedOptionKey] = this.inputFormField.options[optionKey];
         } else {
             let prefixedOptionKey: string = this._transformInputPropertyName(optionKey);
             if (inputPropertyNames.indexOf(prefixedOptionKey) >= 0) {
@@ -141,5 +146,16 @@ export class TerraFormEntryBase implements OnChanges, OnDestroy {
 
     private _transformInputPropertyName(propertyName: string): string {
         return 'input' + propertyName.charAt(0).toUpperCase() + propertyName.substr(1);
+    }
+
+    /**
+     * Removes the prefix 'input' from the given propertyName and lowercases the succeeding character.
+     * @param propertyName
+     */
+    private _removeInputPrefix(propertyName: string): string {
+        if (!propertyName.startsWith('input')) {
+            return propertyName;
+        }
+        return propertyName.charAt(5).toLowerCase() + propertyName.substr(6);
     }
 }


### PR DESCRIPTION
@plentymarkets/team-terra

### Definition of Done

#### Must be done by Terra

Testing

-   [ ] Person 1 (mandatory)

    Browser support (relevant for changes in scss / appearance of components)

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

-   [ ] Person 2 (mandatory)

    Browser support

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

Information transfer

-   [ ] Inform Ceres about changes in `TerraFormComponent` (optional: relevant for changes in this component)

Terra Basic Plugin

-   [ ] Adapt changes (optional: relevant for version updates, global design changes, l10n)

---

#### Must be done by every developer

Please inform a member of Terra (@plentymarkets/team-terra) to get the upper part of the checklist done (with urgency or deadline).

Documentation

-   [ ] Changelog (optional: relevant for every change which influences the API)
-   [ ] Example (updated or created)
-   [ ] JSDoc (optional: relevant for every change which influences the API)
-   [ ] [Google spreadsheet](https://docs.google.com/spreadsheets/d/1OINnux8TEoitV-qdAxqUQaf9oGI_fqFVwfRWenRFfhI/edit#gid=0) (relevant when deprecating public APIs or features)

Testing

-   [ ] Unit Test (updated or created)
