### PR TITLE
feature(build): leverage ng-packagr instead of gulp to copy needed assets

### DIFF
--- a/gulp.config.js
+++ b/gulp.config.js
@@ -12,8 +12,6 @@ module.exports = function () {
     const destinations = {
         tsOutputPath: './dist/',
         styles: './dist/styles/',
-        portletSchematicJson: './dist/schematics/ng-update/terra-portlet-migration',
-
         terra: '../terra/node_modules/@plentymarkets/terra-components/'
     };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,52 +65,7 @@ function copySchematicsJsonFiles() {
     );
 }
 
-function copyFunctionGroupsScss() {
-    return src('src/lib/styles/function-groups.scss').pipe(dest(config.destinations.styles));
-}
-
-function copyVariablesScss() {
-    return src('src/lib/styles/_variables.scss').pipe(dest(config.destinations.styles));
-}
-
-function copyCustomDataTableScss() {
-    return src('src/lib/components/tables/data-table/custom-data-table.scss').pipe(
-        dest('dist/components/tables/data-table')
-    );
-}
-
-function copyNodeTreeScss() {
-    return src('src/lib/components/tree/node-tree/terra-node-tree.component.scss').pipe(
-        dest('dist/components/tree/node-tree')
-    );
-}
-
-function copyTagScss() {
-    return src('src/lib/components/layouts/tag/terra-tag.component.scss').pipe(dest('dist/components/layouts/tag'));
-}
-
-function copyTagListScss() {
-    return src('src/lib/components/layouts/taglist/terra-taglist.component.scss').pipe(
-        dest('dist/components/layouts/taglist')
-    );
-}
-
-function copyButtonScss() {
-    return src('src/lib/components/buttons/button/terra-button.component.scss').pipe(
-        dest('dist/components/buttons/button')
-    );
-}
-
-const copySassFiles = parallel(
-    copyFunctionGroupsScss,
-    copyVariablesScss,
-    copyCustomDataTableScss,
-    copyNodeTreeScss,
-    copyTagScss,
-    copyTagListScss,
-    copyButtonScss
-);
-const copyFilesToDist = parallel(copyReadme, copySassFiles, copySchematicsJsonFiles);
+const copyFilesToDist = parallel(copyReadme, copySchematicsJsonFiles);
 
 //delete terra-components folder in terra
 function cleanUpTerra() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,14 +59,6 @@ function copyReadme() {
     return src(config.sources.readme).pipe(dest(config.destinations.tsOutputPath));
 }
 
-function copySchematicsJsonFiles() {
-    return src('src/lib/schematics/ng-update/terra-portlet-migration/schema.json').pipe(
-        dest(config.destinations.portletSchematicJson)
-    );
-}
-
-const copyFilesToDist = parallel(copyReadme, copySchematicsJsonFiles);
-
 //delete terra-components folder in terra
 function cleanUpTerra() {
     return del(config.destinations.terra + '/**', { force: true });
@@ -80,7 +72,7 @@ function copyToTerra() {
 /**
  * Copies all the files to the dist folder and then to the terra workspace
  **/
-const copy = series(copyFilesToDist, cleanUpTerra, copyToTerra);
+const copy = series(copyReadme, cleanUpTerra, copyToTerra);
 exports.copy = copy;
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-const { series, parallel, src, dest } = require('gulp');
+const { series, src, dest } = require('gulp');
 const config = require('./gulp.config.js')();
 const fs = require('fs');
 const semver = require('semver');

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -55,6 +55,15 @@
         "ts-keycode-enum": "^1.0.6"
     },
     "ngPackage": {
+        "assets": [
+            "./styles/_variables.scss",
+            "./styles/function-groups.scss",
+            "./components/tables/data-table/custom-data-table.scss",
+            "./components/tree/node-tree/terra-node-tree.component.scss",
+            "./components/layouts/tag/terra-tag.component.scss",
+            "./components/layouts/taglist/terra-taglist.component.scss",
+            "./components/buttons/button/terra-button.component.scss"
+        ],
         "lib": {
             "entryFile": "public-api.ts",
             "umdModuleIds": {

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -17,11 +17,7 @@
     ],
     "license": "MIT",
     "scripts": {
-        "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
-        "copy:collection": "cp schematics/collection.json ../../dist/schematics/collection.json",
-        "copy:migrations": "cp schematics/migration.json ../../dist/schematics/migration.json",
-        "copy:schema": "cp schematics/ng-update/checkbox-migration/schema.json ../../dist/schematics/ng-update/checkbox-migration/schema.json",
-        "postbuild": "npm run copy:collection && npm run copy:migrations && npm run copy:schema"
+        "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json"
     },
     "dependencies": {
         "tslib": "^2.3.0"
@@ -62,7 +58,11 @@
             "./components/tree/node-tree/terra-node-tree.component.scss",
             "./components/layouts/tag/terra-tag.component.scss",
             "./components/layouts/taglist/terra-taglist.component.scss",
-            "./components/buttons/button/terra-button.component.scss"
+            "./components/buttons/button/terra-button.component.scss",
+            "./schematics/migration.json",
+            "./schematics/collection.json",
+            "./schematics/ng-update/checkbox-migration/schema.json",
+            "./schematics/ng-update/terra-portlet-migration/schema.json"
         ],
         "lib": {
             "entryFile": "public-api.ts",


### PR DESCRIPTION
See: https://github.com/ng-packagr/ng-packagr/blob/master/docs/copy-assets.md

@plentymarkets/team-terra

### Definition of Done

#### Must be done by Terra

Testing

-   [ ] Person 1 (mandatory)

    Browser support (relevant for changes in scss / appearance of components)

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

-   [ ] Person 2 (mandatory)

    Browser support

    -   [ ] Chrome
    -   [ ] Firefox
    -   [ ] Safari

    Responsiveness

    -   [ ] Desktop
    -   [ ] Tablet
    -   [ ] Mobile

Information transfer

-   [ ] Inform Team plentyShop about changes in `TerraFormComponent` (optional: relevant for changes in this component)

Terra Basic Plugin

-   [ ] Adapt changes (optional: relevant for version updates, global design changes, l10n)

---

#### Must be done by every developer

Please inform a member of Terra (@plentymarkets/team-terra) to get the upper part of the checklist done (with urgency or deadline).

Documentation

-   [ ] Changelog (optional: relevant for every change which influences the API)
-   [ ] Example (updated or created)
-   [ ] JSDoc (optional: relevant for every change which influences the API)
-   [ ] [Google spreadsheet](https://docs.google.com/spreadsheets/d/1OINnux8TEoitV-qdAxqUQaf9oGI_fqFVwfRWenRFfhI/edit#gid=0) (relevant when deprecating public APIs or features)

Testing

-   [ ] Unit Test (updated or created)
